### PR TITLE
re-centre screenshots

### DIFF
--- a/tests/component/specs/cylc-icons.cy.js
+++ b/tests/component/specs/cylc-icons.cy.js
@@ -45,7 +45,7 @@ const TaskComponent = defineComponent({
   render () {
     return h(
       'span',
-      { style: 'font-size: 200px; margin: 100px;' },
+      { style: 'font-size: 200px; margin-left: 100px; margin-top: 50px; display: inline-block' },
       [
         h(Task, this.$attrs)
       ]
@@ -139,7 +139,7 @@ describe('Task component', () => {
         {
           overwrite: true,
           disableTimersAndAnimations: false,
-          padding: [10, 5, 5, 10]
+          padding: [10, 10, 15, 10]
         }
       )
     }


### PR DESCRIPTION
The Cypress tests generate screenshots in tests/e2e/screenshots.

We use these screenshots in the docs: https://cylc.github.io/cylc-doc/stable/html/user-guide/running-workflows/tasks-jobs-ui.html

The icons have become misaligned and don't fit in their boxes any more. This commit nudges them back.